### PR TITLE
Rename classes associated with Figma

### DIFF
--- a/src/main/java/com/ucl/imaginethisserver/Controller/GenerationController.java
+++ b/src/main/java/com/ucl/imaginethisserver/Controller/GenerationController.java
@@ -1,7 +1,7 @@
 package com.ucl.imaginethisserver.Controller;
 
 import com.ucl.imaginethisserver.FigmaComponents.FigmaFile;
-import com.ucl.imaginethisserver.FigmaComponents.Wireframe;
+import com.ucl.imaginethisserver.FigmaComponents.FigmaWireframe;
 import com.ucl.imaginethisserver.Requests.BuildRequest;
 import com.ucl.imaginethisserver.Responses.WireframesResponse;
 import com.ucl.imaginethisserver.Service.GenerationService;
@@ -113,7 +113,7 @@ public class GenerationController {
         Authentication auth = new Authentication(type, accessToken);
         FigmaFile figmaFile = generationService.getFigmaFile(projectID, auth);
         String projectName = figmaFile.getProjectName();
-        List<Wireframe> wireframes = figmaFile.getWireframes();
+        List<FigmaWireframe> wireframes = figmaFile.getWireframes();
         WireframesResponse response = new WireframesResponse(projectID, projectName, wireframes);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/src/main/java/com/ucl/imaginethisserver/FigmaComponents/Button.java
+++ b/src/main/java/com/ucl/imaginethisserver/FigmaComponents/Button.java
@@ -16,7 +16,7 @@ public class Button extends Group {
 
         // Set button's transition to another wireframe if it exists
         if (getTransitionNodeID() != null) {
-            Wireframe transitionWireframe = getFigmaFile().getWireframeById(getTransitionNodeID());
+            FigmaWireframe transitionWireframe = getFigmaFile().getWireframeById(getTransitionNodeID());
             if (transitionWireframe != null) {
                 buttonComponent.setTransitionNodeID(getTransitionNodeID());
                 buttonComponent.setTransitionNodeName(transitionWireframe.getName());

--- a/src/main/java/com/ucl/imaginethisserver/FigmaComponents/FigmaFile.java
+++ b/src/main/java/com/ucl/imaginethisserver/FigmaComponents/FigmaFile.java
@@ -12,35 +12,35 @@ public class FigmaFile {
     private String lastModified;
     private String version;
 
-    private List<Page> pages;
+    private List<FigmaPage> figmaPages;
 
     public FigmaFile(String projectID) {
         this.projectID = projectID;
-        this.pages = new ArrayList<>();
+        this.figmaPages = new ArrayList<>();
     }
 
     public String getProjectID() { return projectID; }
     public String getProjectName() { return projectName; }
     public String getLastModified() { return lastModified; }
     public String getVersion() { return version; }
-    public List<Page> getPages() { return pages; }
+    public List<FigmaPage> getPages() { return figmaPages; }
 
     public void setProjectName(String name) { this.projectName = name; }
     public void setLastModified(String lastModified) { this.lastModified = lastModified; }
     public void setVersion(String version) { this.version = version; }
 
-    public void addPage(Page page) { pages.add(page); }
+    public void addPage(FigmaPage figmaPage) { figmaPages.add(figmaPage); }
 
-    public List<Wireframe> getWireframes() {
-        List<Wireframe> wireframes = new ArrayList<>();
-        for (Page page : pages) {
-            wireframes.addAll(page.getWireframes());
+    public List<FigmaWireframe> getWireframes() {
+        List<FigmaWireframe> wireframes = new ArrayList<>();
+        for (FigmaPage figmaPage : figmaPages) {
+            wireframes.addAll(figmaPage.getWireframes());
         }
         return wireframes;
     }
 
-    public Wireframe getWireframeById(String id) {
-        for (Wireframe wireframe : getWireframes()) {
+    public FigmaWireframe getWireframeById(String id) {
+        for (FigmaWireframe wireframe : getWireframes()) {
             if (wireframe.getId().equals(id)) return wireframe;
         }
         return null;
@@ -48,15 +48,15 @@ public class FigmaFile {
 
     public List<FigmaComponent> getComponents() {
         List<FigmaComponent> figmaComponents = new ArrayList<>();
-        for (Page page : getPages()) {
-            figmaComponents.addAll(page.getComponents());
+        for (FigmaPage figmaPage : getPages()) {
+            figmaComponents.addAll(figmaPage.getComponents());
         }
         return figmaComponents;
     }
     public List<FigmaComponent> getAllComponents() {
         List<FigmaComponent> figmaComponents = new ArrayList<>();
-        for (Page page : getPages()) {
-            figmaComponents.addAll(page.getAllComponents());
+        for (FigmaPage figmaPage : getPages()) {
+            figmaComponents.addAll(figmaPage.getAllComponents());
         }
         return figmaComponents;
     }
@@ -77,8 +77,8 @@ public class FigmaFile {
     }
 
     public void filterWireframesByName(List<String> wireframeList) {
-        for (Page page : getPages()) {
-            page.filterWireframesByName(wireframeList);
+        for (FigmaPage figmaPage : getPages()) {
+            figmaPage.filterWireframesByName(wireframeList);
         }
     }
 }

--- a/src/main/java/com/ucl/imaginethisserver/FigmaComponents/FigmaPage.java
+++ b/src/main/java/com/ucl/imaginethisserver/FigmaComponents/FigmaPage.java
@@ -12,7 +12,7 @@ import java.util.*;
  *  The object contains the id of the page, name of the page and
  *  the wireframes within it listed in the variable children.
  */
-public class Page {
+public class FigmaPage {
     private String id;
     private String name;
     private String type;
@@ -20,9 +20,9 @@ public class Page {
     private JsonArray children;
     private String prototypeStartNodeID;
 
-    private List<Wireframe> wireframes = new ArrayList<>();
+    private List<FigmaWireframe> wireframes = new ArrayList<>();
 
-    private static Logger logger = LoggerFactory.getLogger(Page.class);
+    private static Logger logger = LoggerFactory.getLogger(FigmaPage.class);
 
     public String getId() {
         return id;
@@ -32,10 +32,10 @@ public class Page {
     }
     public String getType() { return type; }
     public JsonArray getChildren() { return children; }
-    public List<Wireframe> getWireframes() { return wireframes; }
+    public List<FigmaWireframe> getWireframes() { return wireframes; }
     public String getPrototypeStartNodeID() { return prototypeStartNodeID; }
 
-    public void addWireframe(Wireframe wireframe) { wireframes.add(wireframe); }
+    public void addWireframe(FigmaWireframe wireframe) { wireframes.add(wireframe); }
 
     /**
      * Function that converts the Figma Page into String
@@ -49,22 +49,22 @@ public class Page {
 
     public List<FigmaComponent> getComponents() {
         List<FigmaComponent> figmaComponents = new ArrayList<>();
-        for (Wireframe wireframe : getWireframes()) {
+        for (FigmaWireframe wireframe : getWireframes()) {
             figmaComponents.addAll(wireframe.getComponents());
         }
         return figmaComponents;
     }
     public List<FigmaComponent> getAllComponents() {
         List<FigmaComponent> figmaComponents = new ArrayList<>();
-        for (Wireframe wireframe : getWireframes()) {
+        for (FigmaWireframe wireframe : getWireframes()) {
             figmaComponents.addAll(wireframe.getAllComponents());
         }
         return figmaComponents;
     }
 
     public void filterWireframesByName(List<String> wireframeList) {
-        List<Wireframe> filteredWireframes = new ArrayList<>();
-        for (Wireframe wireframe : getWireframes()) {
+        List<FigmaWireframe> filteredWireframes = new ArrayList<>();
+        for (FigmaWireframe wireframe : getWireframes()) {
             // Generate only wanted wireframes
             if (!wireframeList.contains(wireframe.getName())) {
                 logger.info("Filtering out wireframe {} from page {}.", wireframe.getName(), getName());

--- a/src/main/java/com/ucl/imaginethisserver/FigmaComponents/FigmaWireframe.java
+++ b/src/main/java/com/ucl/imaginethisserver/FigmaComponents/FigmaWireframe.java
@@ -9,7 +9,7 @@ import java.util.*;
 /**
  * A wireframe object contains the information of a Figma wireframe.
  */
-public class Wireframe {
+public class FigmaWireframe {
     private String id;
     private String name;
     @ExcludeSerialization
@@ -20,7 +20,7 @@ public class Wireframe {
     private String imageURL;
 
     // Parent page, i.e. page in which this wireframe resides
-    private Page page;
+    private FigmaPage figmaPage;
     @ExcludeSerialization
     private List<FigmaComponent> components;
 
@@ -44,15 +44,15 @@ public class Wireframe {
         }
         return allComponents;
     }
-    public Page getPage() {
-        return page;
+    public FigmaPage getPage() {
+        return figmaPage;
     }
     public Color getBackgroundColor() { return backgroundColor; }
     public String getImageURL() { return imageURL; }
 
     public void setName(String name) { this.name = name; }
-    public void setPage(Page page) {
-        this.page = page;
+    public void setPage(FigmaPage figmaPage) {
+        this.figmaPage = figmaPage;
     }
     public void setImageURL(String imageURL) { this.imageURL = imageURL; }
     public void setComponents(List<FigmaComponent> figmaComponents) {

--- a/src/main/java/com/ucl/imaginethisserver/FigmaComponents/ImageButton.java
+++ b/src/main/java/com/ucl/imaginethisserver/FigmaComponents/ImageButton.java
@@ -19,7 +19,7 @@ public class ImageButton extends Group {
         imageButtonComponent.setAlign(this.getAlign());
         if (getTransitionNodeID() != null) {
             imageButtonComponent.setTransitionNodeID(getTransitionNodeID());
-            Wireframe transitionWireframe = getFigmaFile().getWireframeById(getTransitionNodeID());
+            FigmaWireframe transitionWireframe = getFigmaFile().getWireframeById(getTransitionNodeID());
             imageButtonComponent.setTransitionNodeName(transitionWireframe.getName());
         }
         for (FigmaComponent component : getComponents()) {

--- a/src/main/java/com/ucl/imaginethisserver/ReactComponents/AppJSComponent.java
+++ b/src/main/java/com/ucl/imaginethisserver/ReactComponents/AppJSComponent.java
@@ -3,7 +3,7 @@ package com.ucl.imaginethisserver.ReactComponents;
 import com.ucl.imaginethisserver.FigmaComponents.FigmaComponent;
 import com.ucl.imaginethisserver.FigmaComponents.FigmaFile;
 import com.ucl.imaginethisserver.FigmaComponents.Navigation;
-import com.ucl.imaginethisserver.FigmaComponents.Wireframe;
+import com.ucl.imaginethisserver.FigmaComponents.FigmaWireframe;
 
 import java.io.IOException;
 
@@ -21,7 +21,7 @@ public class AppJSComponent {
                 "import { createStackNavigator } from '@react-navigation/stack';\n" +
                 "import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';\n" +
                 "import { SafeAreaView, Image } from 'react-native';\n");
-        for (Wireframe wireframe : figmaFile.getWireframes()) {
+        for (FigmaWireframe wireframe : figmaFile.getWireframes()) {
             String wireframeName = wireframe.getName();
             importCode.append("import " + wireframeName + " from './components/views/" + wireframeName + ".js';\n");
         }
@@ -61,7 +61,7 @@ public class AppJSComponent {
                     "                        options={{headerShown: false}}/>\n");
         }
         // Add screens for every wireframe
-        for (Wireframe wireframe : figmaFile.getWireframes()) {
+        for (FigmaWireframe wireframe : figmaFile.getWireframes()) {
             viewCode.append("<Stack.Screen\n" +
                             "name='" + wireframe.getName() + "'\n" +
                             "component={" + wireframe.getName() + "}/>\n");

--- a/src/main/java/com/ucl/imaginethisserver/ReactComponents/ReactWireframe.java
+++ b/src/main/java/com/ucl/imaginethisserver/ReactComponents/ReactWireframe.java
@@ -1,15 +1,15 @@
 package com.ucl.imaginethisserver.ReactComponents;
 
-import com.ucl.imaginethisserver.FigmaComponents.Wireframe;
+import com.ucl.imaginethisserver.FigmaComponents.FigmaWireframe;
 import com.ucl.imaginethisserver.FigmaComponents.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class WireframeComponent {
+public class ReactWireframe {
 
-    private Wireframe wireframe;
+    private FigmaWireframe wireframe;
     private List<ReactComponent> components = new ArrayList<>();
 
     private Color backgroundColor;
@@ -24,7 +24,7 @@ public class WireframeComponent {
         }
     }
 
-    public WireframeComponent(List<ReactComponent> reactComponents) {
+    public ReactWireframe(List<ReactComponent> reactComponents) {
         for (ReactComponent component : reactComponents) {
             components.add(component);
         }
@@ -35,7 +35,7 @@ public class WireframeComponent {
      * @param wireframe
      * @throws IOException
      */
-    public WireframeComponent(Wireframe wireframe) {
+    public ReactWireframe(FigmaWireframe wireframe) {
         this.wireframe = wireframe;
         this.backgroundColor = wireframe.getBackgroundColor();
         this.absoluteBoundingBox = wireframe.getAbsoluteBoundingBox();

--- a/src/main/java/com/ucl/imaginethisserver/Responses/WireframesResponse.java
+++ b/src/main/java/com/ucl/imaginethisserver/Responses/WireframesResponse.java
@@ -1,6 +1,6 @@
 package com.ucl.imaginethisserver.Responses;
 
-import com.ucl.imaginethisserver.FigmaComponents.Wireframe;
+import com.ucl.imaginethisserver.FigmaComponents.FigmaWireframe;
 
 import java.util.List;
 
@@ -10,9 +10,9 @@ public class WireframesResponse {
 
     private String projectName;
 
-    private List<Wireframe> wireframes;
+    private List<FigmaWireframe> wireframes;
 
-    public WireframesResponse(String projectID, String projectName, List<Wireframe> wireframes) {
+    public WireframesResponse(String projectID, String projectName, List<FigmaWireframe> wireframes) {
         this.projectID = projectID;
         this.projectName = projectName;
         this.wireframes = wireframes;

--- a/src/main/java/com/ucl/imaginethisserver/Util/CodeGenerator.java
+++ b/src/main/java/com/ucl/imaginethisserver/Util/CodeGenerator.java
@@ -1,10 +1,10 @@
 package com.ucl.imaginethisserver.Util;
 
 import com.ucl.imaginethisserver.FigmaComponents.FigmaFile;
-import com.ucl.imaginethisserver.FigmaComponents.Wireframe;
+import com.ucl.imaginethisserver.FigmaComponents.FigmaWireframe;
 import com.ucl.imaginethisserver.ReactComponents.AppJSComponent;
 import com.ucl.imaginethisserver.ReactComponents.ReactComponent;
-import com.ucl.imaginethisserver.ReactComponents.WireframeComponent;
+import com.ucl.imaginethisserver.ReactComponents.ReactWireframe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,10 +83,10 @@ public class CodeGenerator {
      */
     public void generateWireframes(FigmaFile figmaFile) throws IOException {
         String projectDirectory = outputStorageFolder + "/" + figmaFile.getProjectID();
-        for (Wireframe wireframe : figmaFile.getWireframes()) {
+        for (FigmaWireframe wireframe : figmaFile.getWireframes()) {
             String wireframeName = wireframe.getName();
-            WireframeComponent wireframeComponent = new WireframeComponent(wireframe);
-            String outputCode = wireframeComponent.generateCode();
+            ReactWireframe reactWireframe = new ReactWireframe(wireframe);
+            String outputCode = reactWireframe.generateCode();
             fileUtil.writeFile(projectDirectory + "/components/views/" + wireframeName + ".js", outputCode);
         }
     }
@@ -99,9 +99,9 @@ public class CodeGenerator {
     public void generateReusableComponents(FigmaFile figmaFile) throws IOException {
         // Find out all the components in the project that require reusable component
         Set<String> reusableComponents = new HashSet<>();
-        for (Wireframe wireframe : figmaFile.getWireframes()) {
-            WireframeComponent wireframeComponent = new WireframeComponent(wireframe);
-            for (ReactComponent component : wireframeComponent.getComponents()) {
+        for (FigmaWireframe wireframe : figmaFile.getWireframes()) {
+            ReactWireframe reactWireframe = new ReactWireframe(wireframe);
+            for (ReactComponent component : reactWireframe.getComponents()) {
                 if (component.requiresReusableComponent()) {
                     reusableComponents.add(component.getReusableComponentName());
                 }

--- a/src/test/java/com/ucl/imaginethisserver/FigmaComponents/FigmaWireframeTest.java
+++ b/src/test/java/com/ucl/imaginethisserver/FigmaComponents/FigmaWireframeTest.java
@@ -4,11 +4,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class WireframeTest {
+public class FigmaWireframeTest {
 
     @Test
     void givenMalformedWireframeName_whenRequested_thenReturnSanitizedName() {
-        Wireframe wireframe = new Wireframe();
+        FigmaWireframe wireframe = new FigmaWireframe();
         // Make sure wireframe names are capitalized, because they will form React classes
         wireframe.setName("wireframe");
         assertEquals("Wireframe", wireframe.getName());

--- a/src/test/java/com/ucl/imaginethisserver/ReactComponents/ReactWireframeTest.java
+++ b/src/test/java/com/ucl/imaginethisserver/ReactComponents/ReactWireframeTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class WireframeComponentTest {
+public class ReactWireframeTest {
 
     @Test
     void getInlineComponentList() {
@@ -40,8 +40,8 @@ public class WireframeComponentTest {
         d.setPositionY(100);
         reactComponents.add(d);
 
-        WireframeComponent wireframeComponent = new WireframeComponent(reactComponents);
-        List<List<ReactComponent>> inlineList = ReactComponent.getInlineComponentList(wireframeComponent.getComponents());
+        ReactWireframe reactWireframe = new ReactWireframe(reactComponents);
+        List<List<ReactComponent>> inlineList = ReactComponent.getInlineComponentList(reactWireframe.getComponents());
         assertEquals(3, inlineList.size());
         assertEquals(1, inlineList.get(0).size());
         assertEquals(2, inlineList.get(1).size());

--- a/src/test/java/com/ucl/imaginethisserver/Service/GenerationServiceImplTest.java
+++ b/src/test/java/com/ucl/imaginethisserver/Service/GenerationServiceImplTest.java
@@ -7,8 +7,8 @@ import com.ucl.imaginethisserver.DAO.DAOImpl.ConversionDaoImpl;
 import com.ucl.imaginethisserver.DAO.DAOImpl.ProjectDaoImpl;
 import com.ucl.imaginethisserver.Util.*;
 import com.ucl.imaginethisserver.FigmaComponents.FigmaFile;
-import com.ucl.imaginethisserver.FigmaComponents.Page;
-import com.ucl.imaginethisserver.FigmaComponents.Wireframe;
+import com.ucl.imaginethisserver.FigmaComponents.FigmaPage;
+import com.ucl.imaginethisserver.FigmaComponents.FigmaWireframe;
 import com.ucl.imaginethisserver.Service.ServiceImpl.GenerationServiceImpl;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,16 +82,16 @@ public class GenerationServiceImplTest {
         assertEquals("2021-02-14T08:52:49Z", testFigmaFile.getLastModified());
         assertEquals("677374936", testFigmaFile.getVersion());
 
-        List<Page> pages = testFigmaFile.getPages();
-        List<Wireframe> wireframes = testFigmaFile.getWireframes();
+        List<FigmaPage> figmaPages = testFigmaFile.getPages();
+        List<FigmaWireframe> wireframes = testFigmaFile.getWireframes();
         // Secondly, check there is 1 page inside the project with correct name and ID
-        assertEquals(1, pages.size());
-        assertEquals("0:1", pages.get(0).getId());
-        assertEquals("Page 1", pages.get(0).getName());
+        assertEquals(1, figmaPages.size());
+        assertEquals("0:1", figmaPages.get(0).getId());
+        assertEquals("Page 1", figmaPages.get(0).getName());
 
         // Thirdly, check 2 wireframes inside the project with correct names
         assertEquals(2, wireframes.size());
-        for (Wireframe wireframe : wireframes) {
+        for (FigmaWireframe wireframe : wireframes) {
             assertThat(wireframe.getId(), anyOf(is("1:2"), is("202:4")));
             assertThat(wireframe.getName(), anyOf(is("Wireframe1"), is("Wireframe2")));
         }

--- a/src/test/java/com/ucl/imaginethisserver/Util/CodeGeneratorTest.java
+++ b/src/test/java/com/ucl/imaginethisserver/Util/CodeGeneratorTest.java
@@ -66,8 +66,8 @@ public class CodeGeneratorTest {
 
     @Test
     void givenCorrectFigmaFile_whenGeneratingCode_thenCorrectReusableFilesAreCreated() throws IOException {
-        Page testPage = new Page();
-        Wireframe testWireframe = new Wireframe();
+        FigmaPage testPage = new FigmaPage();
+        FigmaWireframe testWireframe = new FigmaWireframe();
         List<FigmaComponent> testComponents = new ArrayList<>();
         // Add some random components, some of which need a reusable component
         testComponents.add(new Button());


### PR DESCRIPTION
## Changes
Making sure names of classes are coherent. Prefixing certain classes with `Figma` will make it more readable and understandable.

## Tests
Unit tests succeed. I also tested the whole system locally.